### PR TITLE
Fix for incorrect handling of file extensions 

### DIFF
--- a/qordoba/commands/push.py
+++ b/qordoba/commands/push.py
@@ -136,7 +136,7 @@ def push_command(curdir, config, update=False, version=None, files=()):
     source_lang = get_source_language(project)
     lang = next(get_destination_languages(project))
 
-    # add_project_file_formats(get_project_file_formats(config))
+    add_project_file_formats(get_project_file_formats(config))
 
     if not files:
         pattern = get_push_pattern(config)

--- a/qordoba/commands/push.py
+++ b/qordoba/commands/push.py
@@ -5,9 +5,9 @@ import logging
 from qordoba.commands.utils import ask_question, ask_select_multiple, ask_select
 from qordoba.languages import get_source_language, init_language_storage, get_destination_languages
 from qordoba.project import ProjectAPI
-from qordoba.settings import get_push_pattern
+from qordoba.settings import get_push_pattern, get_project_file_formats
 from qordoba.sources import find_files_by_pattern, validate_path, validate_push_pattern, get_content_type_code, \
-    get_mimetype
+    get_mimetype, add_project_file_formats
 
 log = logging.getLogger('qordoba')
 
@@ -135,6 +135,8 @@ def push_command(curdir, config, update=False, version=None, files=()):
     project = api.get_project()
     source_lang = get_source_language(project)
     lang = next(get_destination_languages(project))
+
+    # add_project_file_formats(get_project_file_formats(config))
 
     if not files:
         pattern = get_push_pattern(config)

--- a/qordoba/settings.py
+++ b/qordoba/settings.py
@@ -129,3 +129,10 @@ def get_pull_pattern(config, default=NOTDEFINED):
         if default is not NOTDEFINED:
             return None
         raise PatternNotFound('Pattern not found for target files')
+
+
+def get_project_file_formats(config, default=None):
+    try:
+        return config['file_formats']
+    except (KeyError, IndexError):
+        return None

--- a/qordoba/sources.py
+++ b/qordoba/sources.py
@@ -247,6 +247,19 @@ def find_files_by_pattern(curpath, pattern, lang):
         yield path
 
 
+def add_project_file_formats(formats, target_dict=ALLOWED_EXTENSIONS):
+    """
+    Adds items from the qordoba.yml file_formats key to the list of allowed
+    extensions. This is to support per-project file formats (eg, txt, resx, etc)
+    """
+
+    for key, val in formats.items():
+        for item in val:
+            target_dict[item] = key
+
+    return target_dict
+
+
 def get_content_type_code(path):
     """
     :param qordoba.sources.TranslationFile path:

--- a/qordoba/sources.py
+++ b/qordoba/sources.py
@@ -252,10 +252,10 @@ def add_project_file_formats(formats, target_dict=ALLOWED_EXTENSIONS):
     Adds items from the qordoba.yml file_formats key to the list of allowed
     extensions. This is to support per-project file formats (eg, txt, resx, etc)
     """
-
-    for key, val in formats.items():
-        for item in val:
-            target_dict[item] = key
+    if formats is not None:
+        for key, val in formats.items():
+            for item in val:
+                target_dict[item] = key
 
     return target_dict
 

--- a/qordoba/sources.py
+++ b/qordoba/sources.py
@@ -71,7 +71,7 @@ class TranslationFile(object):
     @property
     def extension(self):
         try:
-            _, extension = self.name.split('.', 1)
+            extension = os.path.splitext(self.name)[1][1:]
         except ValueError:
             extension = None
         return extension

--- a/tests/fixtures/.qordoba.yml
+++ b/tests/fixtures/.qordoba.yml
@@ -1,6 +1,10 @@
 qordoba:
   access_token: 'aaaaaaa-bbbb-cccc-dddd-fffffffff'
   project_id: 1111
+  file_formats:
+    resx:
+      - resx
+      - txt
   push:
     sources:
       - file: 'sources/*'

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from qordoba.settings import load_settings, SettingsError
+from qordoba.settings import load_settings, SettingsError, get_project_file_formats
 
 
 @pytest.fixture
@@ -76,3 +76,9 @@ def test_load_settings_overrite(mock_change_dir):
     assert loaded is True
     assert config['access_token'] == test_access_token
     assert config['project_id'] == test_project_id
+
+
+def test_get_project_file_formats(mock_change_dir):
+    settings, loaded = load_settings(access_token='22', project_id='33')
+    result = get_project_file_formats(settings)
+    assert result['resx'] == ['resx', 'txt']

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -4,7 +4,7 @@ import pytest
 
 from qordoba.languages import Language
 from qordoba.sources import validate_push_pattern, PatternNotValid, create_target_path_by_pattern, to_native, \
-    find_files_by_pattern
+    find_files_by_pattern, TranslationFile
 
 PATTERN1 = 'i18n/<language_code>/translations.json'
 PATTERN2 = 'folder1/values-<language_lang_code>/strings.xml'
@@ -114,4 +114,11 @@ def test_find_files_by_pattern(mock_change_dir, mock_lang_storage, pattern, expe
         assert path.posix_path in expected
 
 
-
+@pytest.mark.parametrize('path,expected', [
+    ('./path/some-path/Resource.Name.resx', 'resx'),
+    ('./path/some-path/Resource.json', 'json'),
+    ('./path/some-path/Resource.That.Has.Many.Testings.json.yml', 'yml'),
+])
+def test_obtaining_the_file_extension(path, expected):
+    f = TranslationFile(path, "en-nz", "./")
+    assert f.extension == expected

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,10 +1,10 @@
 import os
 
 import pytest
-
+from collections import OrderedDict
 from qordoba.languages import Language
 from qordoba.sources import validate_push_pattern, PatternNotValid, create_target_path_by_pattern, to_native, \
-    find_files_by_pattern, TranslationFile
+    find_files_by_pattern, TranslationFile, add_project_file_formats
 
 PATTERN1 = 'i18n/<language_code>/translations.json'
 PATTERN2 = 'folder1/values-<language_lang_code>/strings.xml'
@@ -117,8 +117,21 @@ def test_find_files_by_pattern(mock_change_dir, mock_lang_storage, pattern, expe
 @pytest.mark.parametrize('path,expected', [
     ('./path/some-path/Resource.Name.resx', 'resx'),
     ('./path/some-path/Resource.json', 'json'),
-    ('./path/some-path/Resource.That.Has.Many.Testings.json.yml', 'yml'),
+    ('./path/some-path/Resource.That.Has.Many.Extensions.json.yml', 'yml'),
 ])
-def test_obtaining_the_file_extension(path, expected):
+def test_file_extension(path, expected):
     f = TranslationFile(path, "en-nz", "./")
     assert f.extension == expected
+
+
+def test_add_project_file_formats():
+    inbound = {
+        'resx': ('resx',),
+        'plaintext': ('txt', 'text',),
+    }
+
+    result = add_project_file_formats(inbound)
+
+    assert result['resx'] == 'resx'
+    assert result['txt'] == 'plaintext'
+


### PR DESCRIPTION
Hey @wassemgtk,

Ran into an issue with the CLI today when trying to load a file in the format `Namespace.Resource.json`, the CLI picks up the extension as `Resource.json` instead of `json`. I've modified the extension split code to use `os.path.splitext` and pull the last part of the file extension.

Also, I noticed when using custom file extensions, they are blocked by the `ALLOWED_EXTENSIONS` list. I've extended the yaml config to support `file_formats` for adding custom formats. 

Added tests for all changes, but 5 of the tests in the whole suite were failing when I checked out the project – haven't fixed those. 