### PR TITLE
Add support for specifying files in "pull"

### DIFF
--- a/qordoba/cli.py
+++ b/qordoba/cli.py
@@ -172,9 +172,11 @@ class PullHandler(BaseHandler):
                             help="Work only on specified (comma-separated) languages.")
         parser.add_argument('-f', '--force', dest='force', action='store_true',
                             help='Force to update local translation files. Do not ask approval.')
+        # pull_type_group = parser.add_mutually_exclusive_group()
         parser.add_argument('-b', '--bulk', dest='bulk', action='store_true',
                             help="Force to download languages in bulk, incl. source language.")
-
+        parser.add_argument('-i', '--files', dest='files', nargs='+', type=CommaSeparatedSet(),
+                            help='Specify which files to download.')
         group = parser.add_mutually_exclusive_group()
         group.add_argument('--skip', dest='skip', action='store_true', help='Skip downloading if file exists.')
         group.add_argument('--replace', dest='replace', action='store_true', help='Replace existing file.')
@@ -195,10 +197,14 @@ class PullHandler(BaseHandler):
     def main(self):
         config = self.load_settings()
         languages = []
+        files = []
         if isinstance(self.languages, (list, tuple, set)):
             languages.extend(self.languages)
+        if isinstance(self.files, (list, tuple, set)):
+            files.extend(self.files)
         pull_command(self._curdir, config, languages=set(itertools.chain(*languages)),
-                     in_progress=self.in_progress, update_action=self.get_update_action(), force=self.force, bulk=self.bulk)
+                     in_progress=self.in_progress, update_action=self.get_update_action(),
+                     force=self.force, bulk=self.bulk, files=set(itertools.chain(*files)))
 
 class PushHandler(BaseHandler):
     name = 'push'
@@ -236,7 +242,7 @@ class ListHandler(BaseHandler):
         table = AsciiTable(rows).table
         print(table)
 
-        
+
 class DeleteHandler(BaseHandler):
     name = 'delete'
     help = """

--- a/qordoba/commands/pull.py
+++ b/qordoba/commands/pull.py
@@ -195,7 +195,7 @@ def pull_command(curdir, config, force=False, bulk=False, languages=(), in_progr
 
             if not bulk:
                 '''checking if file extension wanted in config file matches downloaded file. If not, continue'''
-                valid_extension = pattern.split('.')[-1]
+                valid_extension = pattern.split('.')[-1] if pattern else None
                 file_extension = page['url'].split('.')[-1]
                 if valid_extension != file_extension:
                     continue

--- a/qordoba/strategies.py
+++ b/qordoba/strategies.py
@@ -80,7 +80,9 @@ def Filename():
                 data = (yaml.load(stream))
                 languages = []
                 for filename_key_value in self.find_ext(data, 'filenames'):
-                    assert isinstance(ext_key_value, object)
+                    assert isinstance(filename_key_value, object)
                     (filename_key, filename_value) = filename_key_value
                     if filename == filename_value:
                         languages.append()
+            except:
+                pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ PyYAML==3.12
 requests==2.5.1
 furl==0.5.6
 terminaltables==3.1.0
+mock

--- a/shebang/__init__.py
+++ b/shebang/__init__.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-s
+import os
+import sys
+
+
+def read(path, size=-1, encoding="utf-8"):
+    """return file content if file exists"""
+    if not path:
+        return
+    if not os.path.exists(path):
+        return
+    if sys.version_info >= (3, 0):
+        r = open(path, encoding=encoding).read(size)
+    else:
+        r = open(path).read(size)
+    return r
+
+def isshebang(l):
+    """return True if line is shebang"""
+    return l and l.find("#!") == 0
+
+def isbinaryfile(path):
+    if path is None:
+        return None
+    try:
+        if not os.path.exists(path):
+            return
+    except Exception:
+        return
+    fin = open(path, 'rb')
+    try:
+        CHUNKSIZE = 1024
+        while True:
+            chunk = fin.read(CHUNKSIZE)
+            if b'\0' in chunk:  # found null byte
+                return True
+            if len(chunk) < CHUNKSIZE:
+                break  # done
+        return False
+    finally:
+        fin.close()
+
+def shebang(path):
+    """return file/string shebang"""
+    if not path:
+        return
+    path = str(path)
+    if not os.path.exists(path):
+        return
+    if isbinaryfile(path):
+        return
+    content = read(path)
+    lines = content.splitlines()
+    if lines:
+        l = lines[0]  # first line
+        if isshebang(l):
+            l = l.replace("#!", "", 1)
+            return l.lstrip().rstrip()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -80,5 +80,8 @@ def test_load_settings_overrite(mock_change_dir):
 
 def test_get_project_file_formats(mock_change_dir):
     settings, loaded = load_settings(access_token='22', project_id='33')
+    settings['file_formats'] = {
+        'resx': 'resx'
+    }
     result = get_project_file_formats(settings)
-    assert result['resx'] == ['resx', 'txt']
+    assert result['resx'] == 'resx'

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from qordoba.strategies import Extension, Shebang
+from qordoba.strategies import Extension
 
 @pytest.fixture
 def valid_extension():


### PR DESCRIPTION
This PR adds support for a new CLI flag, `pull --files my-file.json,my-other-file.json`.

### Changes
- Add CLI flag
- Update tests
- Aggregate the results of multiple searches for each file via itertools.chain
- Inline the source of Shebang (shebang and its dependencies don't appear to be Pip compatible)
- Fixes a bug where some code attempts to call split on a None (`pattern` can be None)
- Fixes a bug where the Strategy is looking for an undefined variable (changed `ext_key_value` to `filename_key_value`)
- Fixes the `test_get_project_file_formats` test, which relied on `resx` being in the YAML fixture (moved the setup data into the test itself)